### PR TITLE
OT275-60: delete slide endpoint

### DIFF
--- a/src/main/java/com/alkemy/ong/application/repository/ISlideRepository.java
+++ b/src/main/java/com/alkemy/ong/application/repository/ISlideRepository.java
@@ -1,5 +1,10 @@
 package com.alkemy.ong.application.repository;
 
+import com.alkemy.ong.domain.Identifiable;
+
 public interface ISlideRepository {
 
+  boolean exists(Identifiable<Long> identifiable);
+
+  void delete(Identifiable<Long> identifiable);
 }

--- a/src/main/java/com/alkemy/ong/application/service/DeleteSlideUseCaseService.java
+++ b/src/main/java/com/alkemy/ong/application/service/DeleteSlideUseCaseService.java
@@ -1,0 +1,24 @@
+package com.alkemy.ong.application.service;
+
+import com.alkemy.ong.application.exception.ErrorMessage;
+import com.alkemy.ong.application.exception.ObjectNotFound;
+import com.alkemy.ong.application.repository.ISlideRepository;
+import com.alkemy.ong.application.service.usecase.IDeleteSlideUseCase;
+import com.alkemy.ong.domain.Identifiable;
+import lombok.AllArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@AllArgsConstructor
+public class DeleteSlideUseCaseService implements IDeleteSlideUseCase {
+
+  private final ISlideRepository slideRepository;
+
+  @Transactional
+  @Override
+  public void delete(Identifiable<Long> identifiable) {
+    if (!slideRepository.exists(identifiable)) {
+      throw new ObjectNotFound(ErrorMessage.OBJECT_NOT_FOUND.getMessage("Slide"));
+    }
+    slideRepository.delete(identifiable);
+  }
+}

--- a/src/main/java/com/alkemy/ong/application/service/usecase/IDeleteSlideUseCase.java
+++ b/src/main/java/com/alkemy/ong/application/service/usecase/IDeleteSlideUseCase.java
@@ -1,0 +1,9 @@
+package com.alkemy.ong.application.service.usecase;
+
+import com.alkemy.ong.domain.Identifiable;
+
+public interface IDeleteSlideUseCase {
+
+  void delete(Identifiable<Long> identifiable);
+
+}

--- a/src/main/java/com/alkemy/ong/infrastructure/config/spring/SpringBeanConfiguration.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/config/spring/SpringBeanConfiguration.java
@@ -1,7 +1,10 @@
 package com.alkemy.ong.infrastructure.config.spring;
 
+import com.alkemy.ong.application.repository.ISlideRepository;
 import com.alkemy.ong.application.repository.IUserRepository;
+import com.alkemy.ong.application.service.DeleteSlideUseCaseService;
 import com.alkemy.ong.application.service.DeleteUserUseCaseService;
+import com.alkemy.ong.application.service.usecase.IDeleteSlideUseCase;
 import com.alkemy.ong.application.service.usecase.IDeleteUserUseCase;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,5 +15,10 @@ public class SpringBeanConfiguration {
   @Bean
   public IDeleteUserUseCase deleteUserUseCase(IUserRepository userRepository) {
     return new DeleteUserUseCaseService(userRepository);
+  }
+
+  @Bean
+  public IDeleteSlideUseCase deleteSlideUseCase(ISlideRepository slideRepository){
+    return new DeleteSlideUseCaseService(slideRepository);
   }
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/config/spring/SpringBeanConfiguration.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/config/spring/SpringBeanConfiguration.java
@@ -18,7 +18,7 @@ public class SpringBeanConfiguration {
   }
 
   @Bean
-  public IDeleteSlideUseCase deleteSlideUseCase(ISlideRepository slideRepository){
+  public IDeleteSlideUseCase deleteSlideUseCase(ISlideRepository slideRepository) {
     return new DeleteSlideUseCaseService(slideRepository);
   }
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/config/spring/security/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/config/spring/security/SecurityConfig.java
@@ -33,6 +33,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .authorizeRequests()
         .antMatchers(HttpMethod.DELETE, "/users/{id:[\\d+]}")
         .hasAnyRole(Role.USER.name(), Role.ADMIN.name())
+        .antMatchers(HttpMethod.DELETE, "/slides/{id:[\\d+]}")
+        .hasRole(Role.ADMIN.name())
         .anyRequest()
         .authenticated()
         .and()

--- a/src/main/java/com/alkemy/ong/infrastructure/database/repository/SlideRepository.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/database/repository/SlideRepository.java
@@ -1,6 +1,7 @@
 package com.alkemy.ong.infrastructure.database.repository;
 
 import com.alkemy.ong.application.repository.ISlideRepository;
+import com.alkemy.ong.domain.Identifiable;
 import com.alkemy.ong.infrastructure.database.repository.abstraction.ISlideSpringRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -10,4 +11,14 @@ import org.springframework.stereotype.Component;
 public class SlideRepository implements ISlideRepository {
 
   private final ISlideSpringRepository slideSpringRepository;
+
+  @Override
+  public boolean exists(Identifiable<Long> identifiable) {
+    return slideSpringRepository.existsById(identifiable.getId());
+  }
+
+  @Override
+  public void delete(Identifiable<Long> identifiable) {
+    slideSpringRepository.deleteById(identifiable.getId());
+  }
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/resource/SlideResource.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/resource/SlideResource.java
@@ -1,0 +1,24 @@
+package com.alkemy.ong.infrastructure.rest.resource;
+
+import com.alkemy.ong.application.service.usecase.IDeleteSlideUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/slides")
+@RequiredArgsConstructor
+@RestController
+public class SlideResource {
+
+  private final IDeleteSlideUseCase deleteSlideUseCase;
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> delete(@PathVariable Long id) {
+    deleteSlideUseCase.delete(() -> id);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+}

--- a/src/test/java/com/alkemy/ong/application/service/DeleteSlideUseCaseServiceTest.java
+++ b/src/test/java/com/alkemy/ong/application/service/DeleteSlideUseCaseServiceTest.java
@@ -1,0 +1,48 @@
+package com.alkemy.ong.application.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.alkemy.ong.application.exception.ObjectNotFound;
+import com.alkemy.ong.application.repository.ISlideRepository;
+import com.alkemy.ong.domain.Identifiable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DeleteSlideUseCaseServiceTest {
+
+  private DeleteSlideUseCaseService slideService;
+  @Mock
+  private ISlideRepository slideRepository;
+
+  @Mock
+  private Identifiable<Long> identifiable;
+
+  @BeforeEach
+  void setup() {
+    slideService = new DeleteSlideUseCaseService(slideRepository);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenUserDoesNotExist() {
+    given(slideRepository.exists(identifiable)).willReturn(false);
+
+    assertThrows(ObjectNotFound.class, () -> slideService.delete(identifiable));
+  }
+
+  @Test
+  void shouldDeleteUserWhenUserExist() {
+    given(slideRepository.exists(identifiable)).willReturn(true);
+
+    slideService.delete(identifiable);
+
+    verify(slideRepository).exists(identifiable);
+    verify(slideRepository).delete(identifiable);
+  }
+
+}


### PR DESCRIPTION
# [Ticket OT275-60](https://alkemy-labs.atlassian.net/browse/OT275-60)

- Endpoint delete
- Delete slides use case


### HOW HAS THIS BEEN TESTED?


- [X] Postman.
- [x] Unit test.
- [ ] Integration test.
- [ ] No testing required (only applies for tech task).



**Screenshots**:
![EVIDENCE png](https://user-images.githubusercontent.com/96498642/187024842-4b05c208-0553-4cb7-b083-af650d0103b8.png)
![PostmanDeleteOKevidence](https://user-images.githubusercontent.com/96498642/187014771-ba9366c0-a7d0-4dfa-92d7-e1da12c95a75.png)
![DelteSlideThrowsExceptionEvidence](https://user-images.githubusercontent.com/96498642/187014767-e9c304c4-f9ae-4847-aa1f-1785289875bb.png)



### CHECKLIST


- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [ ] I have added the new resource in the Postman Collection file.
