### PR TITLE
OT275-58: Endpoint Creación Slides

### DIFF
--- a/src/main/java/com/alkemy/ong/application/repository/ISlideRepository.java
+++ b/src/main/java/com/alkemy/ong/application/repository/ISlideRepository.java
@@ -17,4 +17,8 @@ public interface ISlideRepository {
 
   List<Slide> findAllSortedByPosition();
 
+  Integer findMaxPosition();
+
+  Slide add(Slide slide);
+
 }

--- a/src/main/java/com/alkemy/ong/application/service/CreateSlideUseCaseService.java
+++ b/src/main/java/com/alkemy/ong/application/service/CreateSlideUseCaseService.java
@@ -1,0 +1,30 @@
+package com.alkemy.ong.application.service;
+
+import com.alkemy.ong.application.repository.ISlideRepository;
+import com.alkemy.ong.application.service.usecase.ICreateSlideUseCase;
+import com.alkemy.ong.application.util.IImageUploader;
+import com.alkemy.ong.domain.Slide;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class CreateSlideUseCaseService implements ICreateSlideUseCase {
+
+  private final ISlideRepository slideRepository;
+
+  private final IImageUploader imageUploader;
+
+  @Override
+  public Slide add(Slide slide) {
+    slide.setImageUrl(imageUploader.upload(slide));
+
+    if (slide.getOrder() == null) {
+      slide.setOrder(nextPosition());
+    }
+
+    return slideRepository.add(slide);
+  }
+
+  private Integer nextPosition() {
+    return slideRepository.findMaxPosition() + 1;
+  }
+}

--- a/src/main/java/com/alkemy/ong/application/service/usecase/ICreateSlideUseCase.java
+++ b/src/main/java/com/alkemy/ong/application/service/usecase/ICreateSlideUseCase.java
@@ -1,0 +1,9 @@
+package com.alkemy.ong.application.service.usecase;
+
+import com.alkemy.ong.domain.Slide;
+
+public interface ICreateSlideUseCase {
+
+  Slide add(Slide slide);
+
+}

--- a/src/main/java/com/alkemy/ong/domain/Slide.java
+++ b/src/main/java/com/alkemy/ong/domain/Slide.java
@@ -1,5 +1,10 @@
 package com.alkemy.ong.domain;
 
+import com.alkemy.ong.application.util.IImage;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Base64;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,11 +14,26 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class Slide {
+public class Slide implements IImage {
 
   private Long id;
   private String imageUrl;
   private Integer order;
   private String text;
+  private String base64FileEncoded;
 
+  @Override
+  public InputStream getContent() {
+    return new ByteArrayInputStream(Base64.getDecoder().decode(base64FileEncoded));
+  }
+
+  @Override
+  public String getContentType() {
+    return "image/jpeg";
+  }
+
+  @Override
+  public String getFileName() {
+    return UUID.randomUUID().toString();
+  }
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/config/spring/SpringBeanConfiguration.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/config/spring/SpringBeanConfiguration.java
@@ -10,6 +10,7 @@ import com.alkemy.ong.application.repository.IRoleRepository;
 import com.alkemy.ong.application.repository.ISlideRepository;
 import com.alkemy.ong.application.repository.ITestimonialRepository;
 import com.alkemy.ong.application.repository.IUserRepository;
+import com.alkemy.ong.application.service.CreateSlideUseCaseService;
 import com.alkemy.ong.application.service.CreateUserUseCaseService;
 import com.alkemy.ong.application.service.DeleteCategoryUseCaseService;
 import com.alkemy.ong.application.service.DeleteCommentUseCaseService;
@@ -28,6 +29,7 @@ import com.alkemy.ong.application.service.UpdateCategoryUserCaseService;
 import com.alkemy.ong.application.service.UpdateOrganizationUseCaseService;
 import com.alkemy.ong.application.service.delegate.IAuthenticationManager;
 import com.alkemy.ong.application.service.delegate.IOperationAllowed;
+import com.alkemy.ong.application.service.usecase.ICreateSlideUseCase;
 import com.alkemy.ong.application.service.usecase.ICreateUserUseCase;
 import com.alkemy.ong.application.service.usecase.IDeleteCategoryUseCase;
 import com.alkemy.ong.application.service.usecase.IDeleteCommentUseCase;
@@ -44,6 +46,7 @@ import com.alkemy.ong.application.service.usecase.ILoginUserUseCase;
 import com.alkemy.ong.application.service.usecase.IUpdateActivityUseCase;
 import com.alkemy.ong.application.service.usecase.IUpdateCategoryUseCase;
 import com.alkemy.ong.application.service.usecase.IUpdateOrganizationUseCase;
+import com.alkemy.ong.application.util.IImageUploader;
 import com.alkemy.ong.infrastructure.database.repository.CategoryRepository;
 import com.alkemy.ong.infrastructure.database.repository.SlideRepository;
 import com.alkemy.ong.infrastructure.database.repository.UserRepository;
@@ -138,6 +141,12 @@ public class SpringBeanConfiguration {
   @Bean
   public IUpdateActivityUseCase updateActivityUseCase(IActivityRepository activityRepository) {
     return new UpdateActivityUseCaseService(activityRepository);
+  }
+
+  @Bean
+  public ICreateSlideUseCase createSlideUseCase(ISlideRepository slideRepository,
+      IImageUploader imageUploader) {
+    return new CreateSlideUseCaseService(slideRepository, imageUploader);
   }
 
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/config/spring/SpringBeanConfiguration.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/config/spring/SpringBeanConfiguration.java
@@ -50,6 +50,7 @@ import com.alkemy.ong.application.util.IImageUploader;
 import com.alkemy.ong.infrastructure.database.repository.CategoryRepository;
 import com.alkemy.ong.infrastructure.database.repository.SlideRepository;
 import com.alkemy.ong.infrastructure.database.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -145,7 +146,7 @@ public class SpringBeanConfiguration {
 
   @Bean
   public ICreateSlideUseCase createSlideUseCase(ISlideRepository slideRepository,
-      IImageUploader imageUploader) {
+      @Qualifier("s3Utils") IImageUploader imageUploader) {
     return new CreateSlideUseCaseService(slideRepository, imageUploader);
   }
 

--- a/src/main/java/com/alkemy/ong/infrastructure/config/spring/security/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/config/spring/security/SecurityConfig.java
@@ -98,6 +98,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .hasRole(Role.ADMIN.name())
         .antMatchers(HttpMethod.DELETE, "/slides/{id:[\\d+]}")
         .hasAnyRole(Role.ADMIN.name(), Role.USER.name())
+        .antMatchers(HttpMethod.POST, "/slides")
+        .hasRole(Role.ADMIN.name())
         .antMatchers(HttpMethod.PUT, "/activities/{id:[\\d+]}")
         .hasAnyRole(Role.ADMIN.name())
         .anyRequest()

--- a/src/main/java/com/alkemy/ong/infrastructure/database/mapper/SlideEntityMapper.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/database/mapper/SlideEntityMapper.java
@@ -35,4 +35,17 @@ public class SlideEntityMapper {
     return slide;
   }
 
+  public SlideEntity toEntity(Slide slide) {
+    if (slide == null) {
+      return null;
+    }
+
+    SlideEntity entity = new SlideEntity();
+    entity.setPosition(slide.getOrder());
+    entity.setText(slide.getText());
+    entity.setImageUrl(slide.getImageUrl());
+
+    return entity;
+  }
+
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/database/repository/SlideRepository.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/database/repository/SlideRepository.java
@@ -48,4 +48,15 @@ public class SlideRepository implements ISlideRepository {
     return slideEntityMapper.toDomain(slideSpringRepository.findAllByOrderByPosition());
   }
 
+  @Override
+  public Integer findMaxPosition() {
+    return slideSpringRepository.maxPosition();
+  }
+
+  @Override
+  public Slide add(Slide slide) {
+    SlideEntity entity = slideEntityMapper.toEntity(slide);
+    return slideEntityMapper.toDomain(slideSpringRepository.save(entity));
+  }
+
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/database/repository/abstraction/ISlideSpringRepository.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/database/repository/abstraction/ISlideSpringRepository.java
@@ -3,6 +3,7 @@ package com.alkemy.ong.infrastructure.database.repository.abstraction;
 import com.alkemy.ong.infrastructure.database.entity.SlideEntity;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,4 +12,8 @@ public interface ISlideSpringRepository extends JpaRepository<SlideEntity, Long>
   List<SlideEntity> findAll();
 
   List<SlideEntity> findAllByOrderByPosition();
+
+  @Query("SELECT COALESCE(MAX(s.position), 0) FROM SlideEntity s")
+  Integer maxPosition();
+  
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/mapper/PostSlideMapper.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/mapper/PostSlideMapper.java
@@ -1,0 +1,31 @@
+package com.alkemy.ong.infrastructure.rest.mapper;
+
+import com.alkemy.ong.domain.Slide;
+import com.alkemy.ong.infrastructure.rest.request.SlideRequest;
+import com.alkemy.ong.infrastructure.rest.response.SlideWithTextResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostSlideMapper {
+
+  public Slide toDomain(SlideRequest slideRequest) {
+    if (slideRequest == null) {
+      return null;
+    }
+
+    Slide slide = new Slide();
+    slide.setOrder(slideRequest.getOrder());
+    slide.setText(slideRequest.getText());
+    slide.setBase64FileEncoded(slideRequest.getBase64FileEncoded());
+
+    return slide;
+  }
+
+  public SlideWithTextResponse toResponse(Slide slide) {
+    if (slide == null) {
+      return null;
+    }
+    return new SlideWithTextResponse(slide.getImageUrl(), slide.getOrder(), slide.getText());
+  }
+
+}

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/request/SlideRequest.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/request/SlideRequest.java
@@ -1,0 +1,16 @@
+package com.alkemy.ong.infrastructure.rest.request;
+
+import javax.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SlideRequest {
+
+  private String text;
+  private String order;
+  @NotBlank(message = "File must not be empty and must be base64 encoded")
+  private String base64FileEncoded;
+
+}

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/request/SlideRequest.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/request/SlideRequest.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 public class SlideRequest {
 
   private String text;
-  private String order;
+  private Integer order;
   @NotBlank(message = "File must not be empty and must be base64 encoded")
   private String base64FileEncoded;
 

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/resource/SlideResource.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/resource/SlideResource.java
@@ -1,13 +1,18 @@
 package com.alkemy.ong.infrastructure.rest.resource;
 
+import com.alkemy.ong.application.service.usecase.ICreateSlideUseCase;
 import com.alkemy.ong.application.service.usecase.IDeleteSlideUseCase;
 import com.alkemy.ong.application.service.usecase.IGetSlideUseCase;
 import com.alkemy.ong.application.service.usecase.IListSlideUseCase;
 import com.alkemy.ong.domain.Slide;
 import com.alkemy.ong.infrastructure.rest.mapper.GetSlideMapper;
 import com.alkemy.ong.infrastructure.rest.mapper.ListSlideMapper;
+import com.alkemy.ong.infrastructure.rest.mapper.PostSlideMapper;
+import com.alkemy.ong.infrastructure.rest.request.SlideRequest;
 import com.alkemy.ong.infrastructure.rest.response.GetSlideResponse;
 import com.alkemy.ong.infrastructure.rest.response.ListSlideResponse;
+import com.alkemy.ong.infrastructure.rest.response.SlideWithTextResponse;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -15,6 +20,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,9 +36,13 @@ public class SlideResource {
 
   private final IGetSlideUseCase getSlideUseCase;
 
+  private final ICreateSlideUseCase createSlideUseCase;
+
   private final ListSlideMapper listSlideMapper;
 
   private final GetSlideMapper getSlideMapper;
+
+  private final PostSlideMapper postSlideMapper;
 
   @DeleteMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<Void> delete(@PathVariable Long id) {
@@ -49,6 +60,15 @@ public class SlideResource {
   public ResponseEntity<GetSlideResponse> getBy(@PathVariable Long id) {
     Slide slide = getSlideUseCase.getBy(() -> id);
     return ResponseEntity.ok().body(getSlideMapper.toResponse(slide));
+  }
+
+  @PostMapping(
+      produces = MediaType.APPLICATION_JSON_VALUE,
+      consumes = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<SlideWithTextResponse> add(@Valid @RequestBody SlideRequest slideRequest) {
+    Slide slide = postSlideMapper.toDomain(slideRequest);
+    Slide createdSlide = createSlideUseCase.add(slide);
+    return new ResponseEntity<>(postSlideMapper.toResponse(createdSlide), HttpStatus.CREATED);
   }
 
 }

--- a/src/test/java/com/alkemy/ong/application/service/CreateSlideUseCaseServiceTest.java
+++ b/src/test/java/com/alkemy/ong/application/service/CreateSlideUseCaseServiceTest.java
@@ -45,13 +45,13 @@ class CreateSlideUseCaseServiceTest {
   void shouldSetNextPositionWhenOrderIsNull() {
     Slide slideWithNullOrder = SlideMother.withNullOrder();
     Integer random = IntegerMother.random();
-    Slide expected = SlideMother.build("url", "text", random + 1, "");
+    Integer expected = random + 1;
 
     given(slideRepository.findMaxPosition()).willReturn(random);
 
     createSlideUseCaseService.add(slideWithNullOrder);
 
-    assertThat(slideWithNullOrder.getOrder()).isEqualTo(expected.getOrder());
+    assertThat(slideWithNullOrder.getOrder()).isEqualTo(expected);
   }
 
 }

--- a/src/test/java/com/alkemy/ong/application/service/CreateSlideUseCaseServiceTest.java
+++ b/src/test/java/com/alkemy/ong/application/service/CreateSlideUseCaseServiceTest.java
@@ -45,11 +45,7 @@ class CreateSlideUseCaseServiceTest {
   void shouldSetNextPositionWhenOrderIsNull() {
     Slide slideWithNullOrder = SlideMother.withNullOrder();
     Integer random = IntegerMother.random();
-    Slide expected = SlideMother.build(
-        "url",
-        "text",
-        random + 1,
-        "");
+    Slide expected = SlideMother.build("url", "text", random + 1, "");
 
     given(slideRepository.findMaxPosition()).willReturn(random);
 

--- a/src/test/java/com/alkemy/ong/application/service/CreateSlideUseCaseServiceTest.java
+++ b/src/test/java/com/alkemy/ong/application/service/CreateSlideUseCaseServiceTest.java
@@ -1,0 +1,61 @@
+package com.alkemy.ong.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.alkemy.ong.application.repository.ISlideRepository;
+import com.alkemy.ong.application.util.IImageUploader;
+import com.alkemy.ong.common.IntegerMother;
+import com.alkemy.ong.common.SlideMother;
+import com.alkemy.ong.domain.Slide;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CreateSlideUseCaseServiceTest {
+
+  private CreateSlideUseCaseService createSlideUseCaseService;
+
+  @Mock
+  private ISlideRepository slideRepository;
+
+  @Mock
+  private IImageUploader imageUploader;
+
+  @BeforeEach
+  void setUp() {
+    createSlideUseCaseService = new CreateSlideUseCaseService(slideRepository, imageUploader);
+  }
+
+  @Test
+  void shouldAddSlide() {
+    Slide expected = SlideMother.random();
+
+    createSlideUseCaseService.add(expected);
+
+    verify(slideRepository, times(1)).add(expected);
+  }
+
+  @Test
+  void shouldSetNextPositionWhenOrderIsNull() {
+    Slide slideWithNullOrder = SlideMother.withNullOrder();
+    Integer random = IntegerMother.random();
+    Slide expected = SlideMother.build(
+        "url",
+        "text",
+        random + 1,
+        "");
+
+    given(slideRepository.findMaxPosition()).willReturn(random);
+
+    createSlideUseCaseService.add(slideWithNullOrder);
+
+    assertThat(slideWithNullOrder.getOrder()).isEqualTo(expected.getOrder());
+  }
+
+}

--- a/src/test/java/com/alkemy/ong/common/IntegerMother.java
+++ b/src/test/java/com/alkemy/ong/common/IntegerMother.java
@@ -1,0 +1,11 @@
+package com.alkemy.ong.common;
+
+import java.util.Random;
+
+public class IntegerMother {
+
+  public static Integer random() {
+    return new Random().nextInt();
+  }
+
+}

--- a/src/test/java/com/alkemy/ong/common/SlideMother.java
+++ b/src/test/java/com/alkemy/ong/common/SlideMother.java
@@ -1,0 +1,29 @@
+package com.alkemy.ong.common;
+
+import com.alkemy.ong.domain.Slide;
+
+public class SlideMother {
+
+  public static Slide build(String imageUrl, String text, Integer order, String base64fileEncoded) {
+    return new Slide(null, imageUrl, order, text, base64fileEncoded);
+  }
+
+  public static Slide random() {
+    return new Slide(
+        null,
+        null,
+        IntegerMother.random(),
+        "",
+        "");
+  }
+
+  public static Slide withNullOrder() {
+    return new Slide(
+        null,
+        null,
+        null,
+        "test",
+        "");
+  }
+
+}

--- a/src/test/java/com/alkemy/ong/common/SlideMother.java
+++ b/src/test/java/com/alkemy/ong/common/SlideMother.java
@@ -4,10 +4,6 @@ import com.alkemy.ong.domain.Slide;
 
 public class SlideMother {
 
-  public static Slide build(String imageUrl, String text, Integer order, String base64fileEncoded) {
-    return new Slide(null, imageUrl, order, text, base64fileEncoded);
-  }
-
   public static Slide random() {
     return new Slide(
         null,

--- a/src/test/java/com/alkemy/ong/common/SlideMother.java
+++ b/src/test/java/com/alkemy/ong/common/SlideMother.java
@@ -5,21 +5,11 @@ import com.alkemy.ong.domain.Slide;
 public class SlideMother {
 
   public static Slide random() {
-    return new Slide(
-        null,
-        null,
-        IntegerMother.random(),
-        "",
-        "");
+    return new Slide(null, null, IntegerMother.random(), "", "");
   }
 
   public static Slide withNullOrder() {
-    return new Slide(
-        null,
-        null,
-        null,
-        "test",
-        "");
+    return new Slide(null, null, null, "test", "");
   }
 
 }


### PR DESCRIPTION
# [OT275-58](https://alkemy-labs.atlassian.net/browse/OT275-58)

I have added post slide endoint and unit test.
when a slide is created it is verified that the file field is not empty.
the order field is set with the next position in the slide if it is null
the image is decoded and stored in amazon s3

### HOW HAS THIS BEEN TESTED?

- [x] Postman.
- [x] Unit test.
- [ ] Integration test.
- [ ] No testing required (only applies for tech task).

**Screenshots**:

![Captura desde 2022-09-04 18-08-01](https://user-images.githubusercontent.com/40841894/188335489-ef54e6c7-3fbc-43ae-9c47-b610e4cc7b6e.png)
![Captura desde 2022-09-04 18-08-22](https://user-images.githubusercontent.com/40841894/188335491-44edd906-8f4f-466b-8db0-aed28cb72dac.png)


### CHECKLIST

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added the new resource in the Postman Collection file.
