### PR TITLE
OT275 83: Agregar paginación a Miembros

### DIFF
--- a/src/main/java/com/alkemy/ong/application/repository/IMemberRepository.java
+++ b/src/main/java/com/alkemy/ong/application/repository/IMemberRepository.java
@@ -1,10 +1,16 @@
 package com.alkemy.ong.application.repository;
 
+import com.alkemy.ong.domain.Category;
 import com.alkemy.ong.domain.Identifiable;
+import com.alkemy.ong.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface IMemberRepository {
 
   void delete(Identifiable<Long> identificable);
 
   boolean exists(Identifiable<Long> identificable);
+
+  Page<Member> findAll(Pageable pageable);
 }

--- a/src/main/java/com/alkemy/ong/application/repository/IMemberRepository.java
+++ b/src/main/java/com/alkemy/ong/application/repository/IMemberRepository.java
@@ -1,6 +1,5 @@
 package com.alkemy.ong.application.repository;
 
-import com.alkemy.ong.domain.Category;
 import com.alkemy.ong.domain.Identifiable;
 import com.alkemy.ong.domain.Member;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/alkemy/ong/application/service/ListMemberUseCaseService.java
+++ b/src/main/java/com/alkemy/ong/application/service/ListMemberUseCaseService.java
@@ -1,0 +1,19 @@
+package com.alkemy.ong.application.service;
+
+import com.alkemy.ong.application.repository.IMemberRepository;
+import com.alkemy.ong.application.service.usecase.IListMemberUseCase;
+import com.alkemy.ong.domain.Category;
+import com.alkemy.ong.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+@RequiredArgsConstructor
+public class ListMemberUseCaseService implements IListMemberUseCase {
+  private final IMemberRepository memberRepository;
+
+  @Override
+  public Page<Member> findAll(Pageable pageable) {
+    return memberRepository.findAll(pageable);
+  }
+}

--- a/src/main/java/com/alkemy/ong/application/service/ListMemberUseCaseService.java
+++ b/src/main/java/com/alkemy/ong/application/service/ListMemberUseCaseService.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 
 @RequiredArgsConstructor
 public class ListMemberUseCaseService implements IListMemberUseCase {
+
   private final IMemberRepository memberRepository;
 
   @Override

--- a/src/main/java/com/alkemy/ong/application/service/ListMemberUseCaseService.java
+++ b/src/main/java/com/alkemy/ong/application/service/ListMemberUseCaseService.java
@@ -2,7 +2,6 @@ package com.alkemy.ong.application.service;
 
 import com.alkemy.ong.application.repository.IMemberRepository;
 import com.alkemy.ong.application.service.usecase.IListMemberUseCase;
-import com.alkemy.ong.domain.Category;
 import com.alkemy.ong.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/alkemy/ong/application/service/usecase/IListMemberUseCase.java
+++ b/src/main/java/com/alkemy/ong/application/service/usecase/IListMemberUseCase.java
@@ -1,0 +1,10 @@
+package com.alkemy.ong.application.service.usecase;
+
+import com.alkemy.ong.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface IListMemberUseCase {
+
+  Page<Member> findAll(Pageable pageable);
+}

--- a/src/main/java/com/alkemy/ong/application/service/usecase/IListMemberUseCase.java
+++ b/src/main/java/com/alkemy/ong/application/service/usecase/IListMemberUseCase.java
@@ -7,4 +7,5 @@ import org.springframework.data.domain.Pageable;
 public interface IListMemberUseCase {
 
   Page<Member> findAll(Pageable pageable);
+
 }

--- a/src/main/java/com/alkemy/ong/domain/Member.java
+++ b/src/main/java/com/alkemy/ong/domain/Member.java
@@ -1,0 +1,15 @@
+package com.alkemy.ong.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Member {
+
+  private Long memberId;
+  private String name;
+  private SocialMedia socialMedia;
+  private String imageUrl;
+  private String description;
+}

--- a/src/main/java/com/alkemy/ong/infrastructure/common/PaginatedResultsRetrieved.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/common/PaginatedResultsRetrieved.java
@@ -75,7 +75,7 @@ public class PaginatedResultsRetrieved {
 
   String constructLastPageUri(final UriComponentsBuilder uriBuilder,
       final int totalPages, final int size) {
-    return uriBuilder.replaceQueryParam("page", totalPages -1)
+    return uriBuilder.replaceQueryParam("page", totalPages - 1)
         .replaceQueryParam("size", size).build().encode().toUriString();
   }
 

--- a/src/main/java/com/alkemy/ong/infrastructure/common/PaginatedResultsRetrieved.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/common/PaginatedResultsRetrieved.java
@@ -75,7 +75,7 @@ public class PaginatedResultsRetrieved {
 
   String constructLastPageUri(final UriComponentsBuilder uriBuilder,
       final int totalPages, final int size) {
-    return uriBuilder.replaceQueryParam("page", totalPages)
+    return uriBuilder.replaceQueryParam("page", totalPages -1)
         .replaceQueryParam("size", size).build().encode().toUriString();
   }
 

--- a/src/main/java/com/alkemy/ong/infrastructure/config/spring/SpringBeanConfiguration.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/config/spring/SpringBeanConfiguration.java
@@ -31,6 +31,7 @@ import com.alkemy.ong.application.service.GetSlideUseCaseService;
 import com.alkemy.ong.application.service.ListCategoryUseCaseService;
 import com.alkemy.ong.application.service.ListCommentUseCaseService;
 import com.alkemy.ong.application.service.ListContactUseCaseService;
+import com.alkemy.ong.application.service.ListMemberUseCaseService;
 import com.alkemy.ong.application.service.ListSlideUseCaseService;
 import com.alkemy.ong.application.service.ListUserUseCaseService;
 import com.alkemy.ong.application.service.LoginUserUseCaseService;
@@ -61,6 +62,7 @@ import com.alkemy.ong.application.service.usecase.IGetSlideUseCase;
 import com.alkemy.ong.application.service.usecase.IListCategoryUseCase;
 import com.alkemy.ong.application.service.usecase.IListCommentUseCase;
 import com.alkemy.ong.application.service.usecase.IListContactUseCase;
+import com.alkemy.ong.application.service.usecase.IListMemberUseCase;
 import com.alkemy.ong.application.service.usecase.IListSlideUseCase;
 import com.alkemy.ong.application.service.usecase.IListUserUseCase;
 import com.alkemy.ong.application.service.usecase.ILoginUserUseCase;
@@ -79,6 +81,11 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SpringBeanConfiguration {
+
+  @Bean
+  public IListMemberUseCase listMemberUseCase(IMemberRepository memberRepository) {
+    return new ListMemberUseCaseService(memberRepository);
+  }
 
   @Bean
   public IDeleteMemberUseCase deleteMemberUseCase(IMemberRepository memberRepository) {

--- a/src/main/java/com/alkemy/ong/infrastructure/config/spring/security/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/config/spring/security/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   private static final String CATEGORIES_URL = "/categories";
   private static final String ACTIVITIES_ID_URL = "/activities/{id:[\\d+]}";
   private static final String USERS_ID_URL = "/users/{id:[\\d+]}";
+  private static final String MEMBERS_URL = "/members";
   private static final String MEMBERS_ID_URL = "/members/{id:[\\d+]}";
   private static final String TESTIMONIALS_ID_URL = "/testimonials/{id:[\\d+]}";
   private static final String[] DOCUMENTATION_PATHS = {"/api/docs",
@@ -112,6 +113,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .hasRole(Role.ADMIN.name())
         .antMatchers(HttpMethod.DELETE, CATEGORIES_ID_URL)
         .hasRole(Role.ADMIN.name())
+        .antMatchers(HttpMethod.GET, MEMBERS_URL)
+        .hasRole(Role.USER.name())
         .antMatchers(HttpMethod.DELETE, MEMBERS_ID_URL)
         .hasRole(Role.ADMIN.name())
         .antMatchers(HttpMethod.DELETE, TESTIMONIALS_ID_URL)

--- a/src/main/java/com/alkemy/ong/infrastructure/config/spring/security/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/config/spring/security/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   private static final String ACTIVITIES_ID_URL = "/activities/{id:[\\d+]}";
   private static final String USERS_ID_URL = "/users/{id:[\\d+]}";
   private static final String MEMBERS_URL = "/members";
+  private static final String MEMBERS_PAGING_URL = "/members?page={page:[\\d+]}&size={size:[\\d+]}";
   private static final String MEMBERS_ID_URL = "/members/{id:[\\d+]}";
   private static final String TESTIMONIALS_ID_URL = "/testimonials/{id:[\\d+]}";
   private static final String[] DOCUMENTATION_PATHS = {"/api/docs",
@@ -114,6 +115,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .antMatchers(HttpMethod.DELETE, CATEGORIES_ID_URL)
         .hasRole(Role.ADMIN.name())
         .antMatchers(HttpMethod.GET, MEMBERS_URL)
+        .hasRole(Role.USER.name())
+        .antMatchers(HttpMethod.GET,MEMBERS_PAGING_URL)
         .hasRole(Role.USER.name())
         .antMatchers(HttpMethod.DELETE, MEMBERS_ID_URL)
         .hasRole(Role.ADMIN.name())

--- a/src/main/java/com/alkemy/ong/infrastructure/database/mapper/MemberEntityMapper.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/database/mapper/MemberEntityMapper.java
@@ -1,0 +1,58 @@
+package com.alkemy.ong.infrastructure.database.mapper;
+
+import com.alkemy.ong.domain.Member;
+import com.alkemy.ong.domain.SocialMedia;
+import com.alkemy.ong.infrastructure.database.entity.MemberEntity;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberEntityMapper {
+
+  public Page<Member> toPageDomain(List<MemberEntity> entities,
+      int pages,
+      int size,
+      long totalElements) {
+    return new PageImpl<>(
+        toDomain(entities),
+        PageRequest.of(pages, size), totalElements
+    );
+  }
+
+  private List<Member> toDomain(List<MemberEntity> entities) {
+    if (entities == null) {
+      return Collections.emptyList();
+    }
+    List<Member> members = new ArrayList<>(entities.size());
+    for (MemberEntity member : entities) {
+      members.add(toDomain(member));
+    }
+    return members;
+  }
+
+  private Member toDomain(MemberEntity entity) {
+    if (entity == null) {
+      return null;
+    }
+    Member member = new Member();
+    member.setMemberId(entity.getMemberId());
+    member.setName(entity.getName());
+    member.setSocialMedia(buildSocialMedia(entity));
+    member.setImageUrl(entity.getImageUrl());
+    member.setDescription(entity.getDescription());
+    return member;
+  }
+
+  private SocialMedia buildSocialMedia(MemberEntity entity) {
+    SocialMedia socialMedia = new SocialMedia();
+    socialMedia.setFacebookUrl(entity.getFacebookUrl());
+    socialMedia.setInstagramUrl(entity.getInstagramUrl());
+    socialMedia.setLinkedInUrl(entity.getLinkedInUrl());
+    return socialMedia;
+  }
+}

--- a/src/main/java/com/alkemy/ong/infrastructure/database/mapper/MemberEntityMapper.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/database/mapper/MemberEntityMapper.java
@@ -25,7 +25,7 @@ public class MemberEntityMapper {
   }
 
   private List<Member> toDomain(List<MemberEntity> entities) {
-    if (entities == null) {
+    if (entities == null || entities.isEmpty()) {
       return Collections.emptyList();
     }
     List<Member> members = new ArrayList<>(entities.size());

--- a/src/main/java/com/alkemy/ong/infrastructure/database/repository/MemberRepository.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/database/repository/MemberRepository.java
@@ -2,8 +2,13 @@ package com.alkemy.ong.infrastructure.database.repository;
 
 import com.alkemy.ong.application.repository.IMemberRepository;
 import com.alkemy.ong.domain.Identifiable;
+import com.alkemy.ong.domain.Member;
+import com.alkemy.ong.infrastructure.database.entity.MemberEntity;
+import com.alkemy.ong.infrastructure.database.mapper.MemberEntityMapper;
 import com.alkemy.ong.infrastructure.database.repository.abstraction.IMemberSpringRepository;
 import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 @AllArgsConstructor
@@ -11,6 +16,18 @@ import org.springframework.stereotype.Component;
 public class MemberRepository implements IMemberRepository {
 
   private final IMemberSpringRepository memberSpringRepository;
+  private final MemberEntityMapper memberEntityMapper;
+
+  @Override
+  public Page<Member> findAll(Pageable pageable) {
+    Page<MemberEntity> members = memberSpringRepository.findAllBySoftDeletedFalse(pageable);
+    return memberEntityMapper.toPageDomain(
+        members.getContent(),
+        members.getNumber(),
+        members.getSize(),
+        members.getTotalElements()
+    );
+  }
 
   @Override
   public void delete(Identifiable<Long> identifiable) {

--- a/src/main/java/com/alkemy/ong/infrastructure/database/repository/abstraction/IMemberSpringRepository.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/database/repository/abstraction/IMemberSpringRepository.java
@@ -2,6 +2,8 @@ package com.alkemy.ong.infrastructure.database.repository.abstraction;
 
 import com.alkemy.ong.infrastructure.database.entity.MemberEntity;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +20,5 @@ public interface IMemberSpringRepository extends JpaRepository<MemberEntity, Lon
   @Query(value = "SELECT u FROM MemberEntity u WHERE u.softDeleted = false AND u.memberId = :id")
   Optional<MemberEntity> exists(@Param("id") Long id);
 
+  Page<MemberEntity> findAllBySoftDeletedFalse(Pageable pageable);
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/mapper/GetMemberMapper.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/mapper/GetMemberMapper.java
@@ -3,6 +3,7 @@ package com.alkemy.ong.infrastructure.rest.mapper;
 import com.alkemy.ong.domain.Member;
 import com.alkemy.ong.infrastructure.rest.response.GetMemberResponse;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -14,6 +15,9 @@ public class GetMemberMapper {
   private final SocialMediaMapper socialMediaMapper;
 
   public List<GetMemberResponse> toResponse(List<Member> members) {
+    if (members == null || members.isEmpty()) {
+      return Collections.emptyList();
+    }
     List<GetMemberResponse> memberResponses = new ArrayList<>(members.size());
     for (Member member : members) {
       memberResponses.add(toResponse(member));

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/mapper/GetMemberMapper.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/mapper/GetMemberMapper.java
@@ -1,0 +1,36 @@
+package com.alkemy.ong.infrastructure.rest.mapper;
+
+import com.alkemy.ong.domain.Member;
+import com.alkemy.ong.infrastructure.rest.response.GetMemberResponse;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GetMemberMapper {
+
+  private final SocialMediaMapper socialMediaMapper;
+
+  public List<GetMemberResponse> toResponse(List<Member> members) {
+    List<GetMemberResponse> memberResponses = new ArrayList<>(members.size());
+    for (Member member : members) {
+      memberResponses.add(toResponse(member));
+    }
+    return memberResponses;
+  }
+
+  private GetMemberResponse toResponse(Member member) {
+    if (member == null) {
+      return null;
+    }
+    GetMemberResponse response = new GetMemberResponse();
+    response.setMemberId(member.getMemberId());
+    response.setName(member.getName());
+    response.setSocialMedia(socialMediaMapper.toResponse(member.getSocialMedia()));
+    response.setImageUrl(member.getImageUrl());
+    response.setDescription(member.getDescription());
+    return response;
+  }
+}

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/mapper/ListMemberMapper.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/mapper/ListMemberMapper.java
@@ -1,0 +1,31 @@
+package com.alkemy.ong.infrastructure.rest.mapper;
+
+import com.alkemy.ong.domain.Member;
+import com.alkemy.ong.infrastructure.rest.response.ListMemberResponse;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ListMemberMapper {
+
+  private final GetMemberMapper getMemberMapper;
+
+  public ListMemberResponse toResponse(Page<Member> members) {
+    ListMemberResponse listMemberResponse = toResponse(members.getContent());
+    listMemberResponse.setPage(members.getNumber());
+    listMemberResponse.setSize(members.getSize());
+    listMemberResponse.setTotalPages(members.getTotalPages());
+    return listMemberResponse;
+  }
+
+  private ListMemberResponse toResponse(List<Member> members) {
+    if (members == null) {
+      return new ListMemberResponse(Collections.emptyList());
+    }
+    return new ListMemberResponse(getMemberMapper.toResponse(members));
+  }
+}

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/resource/MemberResource.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/resource/MemberResource.java
@@ -2,15 +2,12 @@ package com.alkemy.ong.infrastructure.rest.resource;
 
 import com.alkemy.ong.application.service.usecase.IDeleteMemberUseCase;
 import com.alkemy.ong.application.service.usecase.IListMemberUseCase;
-import com.alkemy.ong.domain.Category;
 import com.alkemy.ong.domain.Member;
 import com.alkemy.ong.infrastructure.common.PaginatedResultsRetrieved;
 import com.alkemy.ong.infrastructure.rest.mapper.ListMemberMapper;
-import com.alkemy.ong.infrastructure.rest.response.ListCategoryResponse;
 import com.alkemy.ong.infrastructure.rest.response.ListMemberResponse;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -29,9 +26,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 @RequestMapping("/members")
 public class MemberResource {
 
-  @Autowired
   private final IDeleteMemberUseCase deleteMemberUseCase;
-
   private final IListMemberUseCase listMemberUseCase;
   private final ListMemberMapper listMemberMapper;
   private final PaginatedResultsRetrieved resultsRetrieved;
@@ -48,8 +43,7 @@ public class MemberResource {
         resultPage.getTotalPages(),
         resultPage.getSize()
     );
-    ListMemberResponse listMemberResponse = listMemberMapper.toResponse(resultPage);
-    return ResponseEntity.ok().body(listMemberResponse);
+    return ResponseEntity.ok().body(listMemberMapper.toResponse(resultPage));
   }
 
   @DeleteMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/resource/MemberResource.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/resource/MemberResource.java
@@ -1,15 +1,28 @@
 package com.alkemy.ong.infrastructure.rest.resource;
 
 import com.alkemy.ong.application.service.usecase.IDeleteMemberUseCase;
+import com.alkemy.ong.application.service.usecase.IListMemberUseCase;
+import com.alkemy.ong.domain.Category;
+import com.alkemy.ong.domain.Member;
+import com.alkemy.ong.infrastructure.common.PaginatedResultsRetrieved;
+import com.alkemy.ong.infrastructure.rest.mapper.ListMemberMapper;
+import com.alkemy.ong.infrastructure.rest.response.ListCategoryResponse;
+import com.alkemy.ong.infrastructure.rest.response.ListMemberResponse;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,6 +31,26 @@ public class MemberResource {
 
   @Autowired
   private final IDeleteMemberUseCase deleteMemberUseCase;
+
+  private final IListMemberUseCase listMemberUseCase;
+  private final ListMemberMapper listMemberMapper;
+  private final PaginatedResultsRetrieved resultsRetrieved;
+
+  @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<ListMemberResponse> list(@PageableDefault(size = 10) Pageable pageable,
+      UriComponentsBuilder uriBuilder, HttpServletResponse response) {
+    Page<Member> resultPage = listMemberUseCase.findAll(pageable);
+    resultsRetrieved.addLinkHeaderOnPagedResourceRetrieval(
+        uriBuilder,
+        response,
+        "/members",
+        resultPage.getNumber(),
+        resultPage.getTotalPages(),
+        resultPage.getSize()
+    );
+    ListMemberResponse listMemberResponse = listMemberMapper.toResponse(resultPage);
+    return ResponseEntity.ok().body(listMemberResponse);
+  }
 
   @DeleteMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<Void> delete(@PathVariable Long id) {

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/response/GetMemberResponse.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/response/GetMemberResponse.java
@@ -16,4 +16,5 @@ public class GetMemberResponse {
   private SocialMediaResponse socialMedia;
   private String imageUrl;
   private String description;
+
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/response/GetMemberResponse.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/response/GetMemberResponse.java
@@ -1,0 +1,19 @@
+package com.alkemy.ong.infrastructure.rest.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetMemberResponse {
+
+  private Long memberId;
+  private String name;
+  private SocialMediaResponse socialMedia;
+  private String imageUrl;
+  private String description;
+}

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/response/ListMemberResponse.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/response/ListMemberResponse.java
@@ -13,4 +13,5 @@ import lombok.Setter;
 public class ListMemberResponse extends PaginationResponse {
 
   private List<GetMemberResponse> members;
+
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/response/ListMemberResponse.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/response/ListMemberResponse.java
@@ -1,0 +1,16 @@
+package com.alkemy.ong.infrastructure.rest.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class ListMemberResponse extends PaginationResponse {
+
+  private List<GetMemberResponse> members;
+}

--- a/src/test/java/com/alkemy/ong/application/service/ListMemberUseCaseServiceTest.java
+++ b/src/test/java/com/alkemy/ong/application/service/ListMemberUseCaseServiceTest.java
@@ -20,7 +20,7 @@ class ListMemberUseCaseServiceTest {
 
   private ListMemberUseCaseService listMemberUseCaseService;
   @Mock
-  IMemberRepository memberRepository;
+  private IMemberRepository memberRepository;
 
   @BeforeEach
   void setUp() {

--- a/src/test/java/com/alkemy/ong/application/service/ListMemberUseCaseServiceTest.java
+++ b/src/test/java/com/alkemy/ong/application/service/ListMemberUseCaseServiceTest.java
@@ -1,0 +1,40 @@
+package com.alkemy.ong.application.service;
+
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.alkemy.ong.application.repository.IMemberRepository;
+import com.alkemy.ong.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ListMemberUseCaseServiceTest {
+
+  private ListMemberUseCaseService listMemberUseCaseService;
+  @Mock
+  IMemberRepository memberRepository;
+
+  @BeforeEach
+  void setUp() {
+    listMemberUseCaseService = new ListMemberUseCaseService(memberRepository);
+  }
+
+  @Test
+  void shouldReturnPageable() {
+    Pageable pageable = Pageable.unpaged();
+    Page<Member> page = Page.empty();
+
+    given(memberRepository.findAll(pageable)).willReturn(page);
+    listMemberUseCaseService.findAll(pageable);
+
+    verify(memberRepository, times(1)).findAll(pageable);
+  }
+}


### PR DESCRIPTION
# [OT275-83](https://alkemy-labs.atlassian.net/browse/OT275-83)

Added pagination functionality to the list members endpoint. 

### HOW HAS THIS BEEN TESTED?

A unit test was included in the test package, and 

- [x] Postman.
- [x] Unit test.
- [ ] Integration test.
- [ ] No testing required (only applies for tech task).

**Test Configuration**:

No additional configuration was needed to perform this tests

**Screenshots**:
Given a number of "members" on the database
![image](https://user-images.githubusercontent.com/73443385/189439188-9c1b3785-c3e8-4270-b420-0b34cbd02175.png)
When a GET request is sent to the "/members" endpoint
![image](https://user-images.githubusercontent.com/73443385/189439463-4b526ebf-b240-4482-a7bf-f4a54f7d6f40.png)
A list of 10 "members" is returned and in the headers links to other pages are found
![image](https://user-images.githubusercontent.com/73443385/189440799-7764377f-823d-4889-9806-72e435372cfa.png)
Using the links we can access the last page of the list
![image](https://user-images.githubusercontent.com/73443385/189441145-35f356de-eb5d-4d00-ac1f-c5e4c889dc79.png)



* ....

### CHECKLIST

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added the new resource in the Postman Collection file.
