### PR TITLE
OT275-72: Endpoint Actualizacion de Miembros

### DIFF
--- a/src/main/java/com/alkemy/ong/application/repository/IMemberRepository.java
+++ b/src/main/java/com/alkemy/ong/application/repository/IMemberRepository.java
@@ -15,4 +15,5 @@ public interface IMemberRepository {
 
   Member add(Member member);
 
+  Member update(Member member);
 }

--- a/src/main/java/com/alkemy/ong/application/service/member/UpdateMemberUseCaseService.java
+++ b/src/main/java/com/alkemy/ong/application/service/member/UpdateMemberUseCaseService.java
@@ -9,11 +9,12 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class UpdateMemberUseCaseService implements IUpdateMemberUseCase {
+
   private final IMemberRepository memberRepository;
 
   @Override
   public Member update(Member member) {
-    if (!memberRepository.exists(member::getMemberId)){
+    if (!memberRepository.exists(member::getMemberId)) {
       throw new ObjectNotFoundException(ErrorMessage.OBJECT_NOT_FOUND.getMessage("Member"));
     }
     return memberRepository.update(member);

--- a/src/main/java/com/alkemy/ong/application/service/member/UpdateMemberUseCaseService.java
+++ b/src/main/java/com/alkemy/ong/application/service/member/UpdateMemberUseCaseService.java
@@ -1,0 +1,21 @@
+package com.alkemy.ong.application.service.member;
+
+import com.alkemy.ong.application.exception.ErrorMessage;
+import com.alkemy.ong.application.exception.ObjectNotFoundException;
+import com.alkemy.ong.application.repository.IMemberRepository;
+import com.alkemy.ong.application.service.member.usecase.IUpdateMemberUseCase;
+import com.alkemy.ong.domain.Member;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UpdateMemberUseCaseService implements IUpdateMemberUseCase {
+  private final IMemberRepository memberRepository;
+
+  @Override
+  public Member update(Member member) {
+    if (!memberRepository.exists(member::getMemberId)){
+      throw new ObjectNotFoundException(ErrorMessage.OBJECT_NOT_FOUND.getMessage("Member"));
+    }
+    return memberRepository.update(member);
+  }
+}

--- a/src/main/java/com/alkemy/ong/application/service/member/usecase/IUpdateMemberUseCase.java
+++ b/src/main/java/com/alkemy/ong/application/service/member/usecase/IUpdateMemberUseCase.java
@@ -1,0 +1,7 @@
+package com.alkemy.ong.application.service.member.usecase;
+
+import com.alkemy.ong.domain.Member;
+
+public interface IUpdateMemberUseCase {
+  Member update(Member member);
+}

--- a/src/main/java/com/alkemy/ong/infrastructure/config/spring/SpringBeanConfiguration.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/config/spring/SpringBeanConfiguration.java
@@ -319,7 +319,7 @@ public class SpringBeanConfiguration {
   }
 
   @Bean
-  public IUpdateMemberUseCase updateMemberUseCase(IMemberRepository memberRepository){
+  public IUpdateMemberUseCase updateMemberUseCase(IMemberRepository memberRepository) {
     return new UpdateMemberUseCaseService(memberRepository);
   }
 

--- a/src/main/java/com/alkemy/ong/infrastructure/config/spring/SpringBeanConfiguration.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/config/spring/SpringBeanConfiguration.java
@@ -42,9 +42,11 @@ import com.alkemy.ong.application.service.delegate.IOperationAllowed;
 import com.alkemy.ong.application.service.member.CreateMemberUseCaseService;
 import com.alkemy.ong.application.service.member.DeleteMemberUseCaseService;
 import com.alkemy.ong.application.service.member.ListMemberUseCaseService;
+import com.alkemy.ong.application.service.member.UpdateMemberUseCaseService;
 import com.alkemy.ong.application.service.member.usecase.ICreateMemberUseCase;
 import com.alkemy.ong.application.service.member.usecase.IDeleteMemberUseCase;
 import com.alkemy.ong.application.service.member.usecase.IListMemberUseCase;
+import com.alkemy.ong.application.service.member.usecase.IUpdateMemberUseCase;
 import com.alkemy.ong.application.service.news.CreateNewsUseCaseService;
 import com.alkemy.ong.application.service.news.DeleteNewsUseCaseService;
 import com.alkemy.ong.application.service.news.GetNewsUseCaseService;
@@ -314,6 +316,11 @@ public class SpringBeanConfiguration {
   @Bean
   public ICreateMemberUseCase createMemberUseCase(IMemberRepository memberRepository) {
     return new CreateMemberUseCaseService(memberRepository);
+  }
+
+  @Bean
+  public IUpdateMemberUseCase updateMemberUseCase(IMemberRepository memberRepository){
+    return new UpdateMemberUseCaseService(memberRepository);
   }
 
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/config/spring/security/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/config/spring/security/SecurityConfig.java
@@ -133,6 +133,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .hasAnyRole(Role.USER.name(), Role.ADMIN.name())
         .antMatchers(HttpMethod.GET, MEMBERS_PAGING_URL)
         .hasAnyRole(Role.USER.name())
+        .antMatchers(HttpMethod.PUT, MEMBERS_ID_URL)
+        .hasRole(Role.USER.name())
         .antMatchers(HttpMethod.DELETE, MEMBERS_ID_URL)
         .hasAnyRole(Role.ADMIN.name())
         .antMatchers(HttpMethod.DELETE, TESTIMONIALS_ID_URL)

--- a/src/main/java/com/alkemy/ong/infrastructure/database/repository/MemberRepository.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/database/repository/MemberRepository.java
@@ -48,4 +48,10 @@ public class MemberRepository implements IMemberRepository {
 
   }
 
+  @Override
+  public Member update(Member member) {
+    MemberEntity memberEntity = memberEntityMapper.toEntity(member);
+    return memberEntityMapper.toDomain(memberSpringRepository.save(memberEntity));
+  }
+
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/mapper/member/UpdateMemberMapper.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/mapper/member/UpdateMemberMapper.java
@@ -6,13 +6,14 @@ import com.alkemy.ong.infrastructure.rest.request.member.CreateMemberRequest;
 import org.springframework.stereotype.Component;
 
 @Component
-public class UpdateMemberMapper extends CreateMemberMapper{
+public class UpdateMemberMapper extends CreateMemberMapper {
+
   public UpdateMemberMapper(
       SocialMediaMapper socialMediaMapper) {
     super(socialMediaMapper);
   }
 
-  public Member toDomain(Long id, CreateMemberRequest request){
+  public Member toDomain(Long id, CreateMemberRequest request) {
     Member member = super.toDomain(request);
     member.setMemberId(id);
     return member;

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/mapper/member/UpdateMemberMapper.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/mapper/member/UpdateMemberMapper.java
@@ -2,8 +2,7 @@ package com.alkemy.ong.infrastructure.rest.mapper.member;
 
 import com.alkemy.ong.domain.Member;
 import com.alkemy.ong.infrastructure.rest.mapper.common.SocialMediaMapper;
-import com.alkemy.ong.infrastructure.rest.request.member.CreateMemberRequest;
-import com.alkemy.ong.infrastructure.rest.response.member.UpdateMemberResponse;
+import com.alkemy.ong.infrastructure.rest.request.member.UpdateMemberRequest;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,13 +13,16 @@ public class UpdateMemberMapper extends CreateMemberMapper {
     super(socialMediaMapper);
   }
 
-  public Member toDomain(Long id, CreateMemberRequest request) {
-    Member member = super.toDomain(request);
+  public Member toDomain(Long id, UpdateMemberRequest request) {
+    if (request == null) {
+      return null;
+    }
+    Member member = new Member();
     member.setMemberId(id);
+    member.setName(request.getName());
+    member.setImageUrl(request.getImage());
+    member.setDescription(request.getDescription());
+    member.setSocialMedia(socialMediaMapper.toDomain(request.getSocialMedia()));
     return member;
-  }
-
-  public UpdateMemberResponse toResponse(Member member) {
-    return (UpdateMemberResponse) super.toResponse(member);
   }
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/mapper/member/UpdateMemberMapper.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/mapper/member/UpdateMemberMapper.java
@@ -6,7 +6,7 @@ import com.alkemy.ong.infrastructure.rest.request.member.UpdateMemberRequest;
 import org.springframework.stereotype.Component;
 
 @Component
-public class UpdateMemberMapper extends CreateMemberMapper {
+public class UpdateMemberMapper extends GetMemberMapper {
 
   public UpdateMemberMapper(
       SocialMediaMapper socialMediaMapper) {

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/mapper/member/UpdateMemberMapper.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/mapper/member/UpdateMemberMapper.java
@@ -3,6 +3,7 @@ package com.alkemy.ong.infrastructure.rest.mapper.member;
 import com.alkemy.ong.domain.Member;
 import com.alkemy.ong.infrastructure.rest.mapper.common.SocialMediaMapper;
 import com.alkemy.ong.infrastructure.rest.request.member.CreateMemberRequest;
+import com.alkemy.ong.infrastructure.rest.response.member.UpdateMemberResponse;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -17,5 +18,9 @@ public class UpdateMemberMapper extends CreateMemberMapper {
     Member member = super.toDomain(request);
     member.setMemberId(id);
     return member;
+  }
+
+  public UpdateMemberResponse toResponse(Member member){
+    return (UpdateMemberResponse) super.toResponse(member);
   }
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/mapper/member/UpdateMemberMapper.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/mapper/member/UpdateMemberMapper.java
@@ -1,0 +1,20 @@
+package com.alkemy.ong.infrastructure.rest.mapper.member;
+
+import com.alkemy.ong.domain.Member;
+import com.alkemy.ong.infrastructure.rest.mapper.common.SocialMediaMapper;
+import com.alkemy.ong.infrastructure.rest.request.member.CreateMemberRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UpdateMemberMapper extends CreateMemberMapper{
+  public UpdateMemberMapper(
+      SocialMediaMapper socialMediaMapper) {
+    super(socialMediaMapper);
+  }
+
+  public Member toDomain(Long id, CreateMemberRequest request){
+    Member member = super.toDomain(request);
+    member.setMemberId(id);
+    return member;
+  }
+}

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/mapper/member/UpdateMemberMapper.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/mapper/member/UpdateMemberMapper.java
@@ -20,7 +20,7 @@ public class UpdateMemberMapper extends CreateMemberMapper {
     return member;
   }
 
-  public UpdateMemberResponse toResponse(Member member){
+  public UpdateMemberResponse toResponse(Member member) {
     return (UpdateMemberResponse) super.toResponse(member);
   }
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/request/member/UpdateMemberRequest.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/request/member/UpdateMemberRequest.java
@@ -1,0 +1,26 @@
+package com.alkemy.ong.infrastructure.rest.request.member;
+
+import com.alkemy.ong.infrastructure.rest.request.common.SocialMediaRequest;
+import com.alkemy.ong.infrastructure.rest.request.validation.AlphanumericWithoutWhiteSpaces;
+import com.alkemy.ong.infrastructure.rest.request.validation.CharactersWithWhiteSpaces;
+import javax.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UpdateMemberRequest {
+
+  @NotEmpty(message = "Name cannot be empty.")
+  @CharactersWithWhiteSpaces(message = "Name must contain only spaces and letters.")
+  private String name;
+
+  @NotEmpty(message = "Image cannot be empty.")
+  @AlphanumericWithoutWhiteSpaces(message = "Image must be alphanumeric without white spaces.")
+  private String image;
+
+  private String description;
+
+  private SocialMediaRequest socialMedia;
+
+}

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/resource/MemberResource.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/resource/MemberResource.java
@@ -10,8 +10,8 @@ import com.alkemy.ong.infrastructure.rest.mapper.member.CreateMemberMapper;
 import com.alkemy.ong.infrastructure.rest.mapper.member.ListMemberMapper;
 import com.alkemy.ong.infrastructure.rest.mapper.member.UpdateMemberMapper;
 import com.alkemy.ong.infrastructure.rest.request.member.CreateMemberRequest;
+import com.alkemy.ong.infrastructure.rest.request.member.UpdateMemberRequest;
 import com.alkemy.ong.infrastructure.rest.response.member.GetMemberResponse;
-import com.alkemy.ong.infrastructure.rest.response.member.UpdateMemberResponse;
 import com.alkemy.ong.infrastructure.rest.response.news.ListMemberResponse;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
@@ -81,9 +81,9 @@ public class MemberResource {
       value = "{id}",
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<UpdateMemberResponse> update(
+  public ResponseEntity<GetMemberResponse> update(
       @PathVariable Long id,
-      @Valid @RequestBody CreateMemberRequest request) {
+      @Valid @RequestBody UpdateMemberRequest request) {
     Member updatedMember = updateMemberUseCase.update(updateMemberMapper.toDomain(id, request));
     return ResponseEntity.ok().body(updateMemberMapper.toResponse(updatedMember));
   }

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/resource/MemberResource.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/resource/MemberResource.java
@@ -82,8 +82,8 @@ public class MemberResource {
       produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<GetMemberResponse> update(
       @PathVariable Long id,
-      @Valid @RequestBody CreateMemberRequest request){
-    Member updatedMember = updateMemberUseCase.update(updateMemberMapper.toDomain(id,request));
+      @Valid @RequestBody CreateMemberRequest request) {
+    Member updatedMember = updateMemberUseCase.update(updateMemberMapper.toDomain(id, request));
     return ResponseEntity.ok().body(updateMemberMapper.toResponse(updatedMember));
   }
 

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/resource/MemberResource.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/resource/MemberResource.java
@@ -11,6 +11,7 @@ import com.alkemy.ong.infrastructure.rest.mapper.member.ListMemberMapper;
 import com.alkemy.ong.infrastructure.rest.mapper.member.UpdateMemberMapper;
 import com.alkemy.ong.infrastructure.rest.request.member.CreateMemberRequest;
 import com.alkemy.ong.infrastructure.rest.response.member.GetMemberResponse;
+import com.alkemy.ong.infrastructure.rest.response.member.UpdateMemberResponse;
 import com.alkemy.ong.infrastructure.rest.response.news.ListMemberResponse;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
@@ -80,7 +81,7 @@ public class MemberResource {
       value = "{id}",
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<GetMemberResponse> update(
+  public ResponseEntity<UpdateMemberResponse> update(
       @PathVariable Long id,
       @Valid @RequestBody CreateMemberRequest request) {
     Member updatedMember = updateMemberUseCase.update(updateMemberMapper.toDomain(id, request));

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/resource/MemberResource.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/resource/MemberResource.java
@@ -3,10 +3,12 @@ package com.alkemy.ong.infrastructure.rest.resource;
 import com.alkemy.ong.application.service.member.usecase.ICreateMemberUseCase;
 import com.alkemy.ong.application.service.member.usecase.IDeleteMemberUseCase;
 import com.alkemy.ong.application.service.member.usecase.IListMemberUseCase;
+import com.alkemy.ong.application.service.member.usecase.IUpdateMemberUseCase;
 import com.alkemy.ong.domain.Member;
 import com.alkemy.ong.infrastructure.common.PaginatedResultsRetrieved;
 import com.alkemy.ong.infrastructure.rest.mapper.member.CreateMemberMapper;
 import com.alkemy.ong.infrastructure.rest.mapper.member.ListMemberMapper;
+import com.alkemy.ong.infrastructure.rest.mapper.member.UpdateMemberMapper;
 import com.alkemy.ong.infrastructure.rest.request.member.CreateMemberRequest;
 import com.alkemy.ong.infrastructure.rest.response.member.GetMemberResponse;
 import com.alkemy.ong.infrastructure.rest.response.news.ListMemberResponse;
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -38,7 +41,9 @@ public class MemberResource {
   private final ListMemberMapper listMemberMapper;
   private final PaginatedResultsRetrieved resultsRetrieved;
   private final ICreateMemberUseCase createMemberUseCase;
+  private final IUpdateMemberUseCase updateMemberUseCase;
   private final CreateMemberMapper createMemberMapper;
+  private final UpdateMemberMapper updateMemberMapper;
 
   @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<ListMemberResponse> list(@PageableDefault(size = 10) Pageable pageable,
@@ -69,6 +74,17 @@ public class MemberResource {
     Member member = createMemberMapper.toDomain(createMemberRequest);
     Member createdMember = createMemberUseCase.add(member);
     return new ResponseEntity<>(createMemberMapper.toResponse(createdMember), HttpStatus.CREATED);
+  }
+
+  @PutMapping(
+      value = "{id}",
+      consumes = MediaType.APPLICATION_JSON_VALUE,
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<GetMemberResponse> update(
+      @PathVariable Long id,
+      @Valid @RequestBody CreateMemberRequest request){
+    Member updatedMember = updateMemberUseCase.update(updateMemberMapper.toDomain(id,request));
+    return ResponseEntity.ok().body(updateMemberMapper.toResponse(updatedMember));
   }
 
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/response/member/UpdateMemberResponse.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/response/member/UpdateMemberResponse.java
@@ -1,0 +1,5 @@
+package com.alkemy.ong.infrastructure.rest.response.member;
+
+public class UpdateMemberResponse extends GetMemberResponse {
+
+}

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/response/member/UpdateMemberResponse.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/response/member/UpdateMemberResponse.java
@@ -1,5 +1,0 @@
-package com.alkemy.ong.infrastructure.rest.response.member;
-
-public class UpdateMemberResponse extends GetMemberResponse {
-
-}

--- a/src/test/java/com/alkemy/ong/application/service/UpdateMemberUseServiceTest.java
+++ b/src/test/java/com/alkemy/ong/application/service/UpdateMemberUseServiceTest.java
@@ -1,0 +1,51 @@
+package com.alkemy.ong.application.service;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.alkemy.ong.application.exception.ObjectNotFoundException;
+import com.alkemy.ong.application.repository.IMemberRepository;
+import com.alkemy.ong.application.service.member.UpdateMemberUseCaseService;
+import com.alkemy.ong.domain.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateMemberUseCaseServiceTest {
+
+  private UpdateMemberUseCaseService updateMemberUseCaseService;
+
+  @Mock
+  private IMemberRepository memberRepository;
+
+  @Mock
+  private Member member;
+
+  @BeforeEach
+  void setUp() {
+    updateMemberUseCaseService = new UpdateMemberUseCaseService(memberRepository);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenTestimonialDoesNotExist() {
+    given(memberRepository.exists(any())).willReturn(false);
+
+    assertThrows(ObjectNotFoundException.class,
+        () -> updateMemberUseCaseService.update(member));
+  }
+
+  @Test
+  void shouldUpdateTestimonial() {
+    given(memberRepository.exists(any())).willReturn(true);
+    given(memberRepository.update(member)).willReturn(member);
+
+    updateMemberUseCaseService.update(member);
+
+    verify(memberRepository).update(member);
+  }
+
+}


### PR DESCRIPTION
# [OT275-72](https://alkemy-labs.atlassian.net/browse/OT275-72)

Implemented member actualization endpoint at PUT /members/{id}

### HOW HAS THIS BEEN TESTED?

Unit tests and Postman requests were used to test this feature

- [x] Postman.
- [x] Unit test.
- [ ] Integration test.
- [ ] No testing required (only applies for tech task).

**Test Configuration**:

No additional configuration was needed in order to run these tests

**Screenshots**:
Given a member entry in the database:
![image](https://user-images.githubusercontent.com/73443385/191111318-79923fd4-93d8-4b9b-ad85-dfdccf83f15e.png)
When a PUT request is sent to the endpoint:
![image](https://user-images.githubusercontent.com/73443385/191111439-c6536617-4eaf-47f8-b98b-f6d4186ca20b.png)
The results can be seen in the database:
![image](https://user-images.githubusercontent.com/73443385/191111505-e829cf00-302d-4252-99b9-d154b4b5b500.png)
When an incorrect body format is sent, validations take place:
![image](https://user-images.githubusercontent.com/73443385/191111613-88bc5efd-6c4c-49bc-ae24-e0ba278c25d3.png)



### CHECKLIST

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added the new resource in the Postman Collection file.
